### PR TITLE
Code to fix warning in SkipContract.sol

### DIFF
--- a/step04_chap2_textbook/contracts/SkipContract.sol
+++ b/step04_chap2_textbook/contracts/SkipContract.sol
@@ -45,9 +45,9 @@ contract SkipContract {
         returns (function(uint) pure returns(uint) func) 
     {
         if (_fnNumber == 1) {
-            func = skip_1;
+            func = skip1;
         } else if (_fnNumber == 2) {
-            func = skip_2;
+            func = skip2;
         }
     }
 


### PR DESCRIPTION
Warning: Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.
  --> contracts/SkipContract.sol:26:6:
   |
26 |     (function(uint) pure returns(uint) ) {
   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^